### PR TITLE
feat: Line Messaging APIを呼び出すクラスの実装

### DIFF
--- a/app/controllers/line_bot_controller.rb
+++ b/app/controllers/line_bot_controller.rb
@@ -1,5 +1,6 @@
 class LineBotController < ApplicationController
   def callback
-    
+    body = request.body.read
+    Api::LineBot::Message.call(body)
   end
 end

--- a/app/models/api/line_bot/base.rb
+++ b/app/models/api/line_bot/base.rb
@@ -1,0 +1,22 @@
+module Api
+  module LineBot
+    class Base
+      def initialize(body)
+        @events = client.parse_events_from(body)
+      end
+
+      attr_accessor :events
+
+      def call
+        return if events.length == 0
+      end
+
+      def client
+        @client ||= Line::Bot::Client.new { |config|
+          config.channel_secret = ENV["LINE_CHANNEL_SECRET"]
+          config.channel_token = ENV["LINE_CHANNEL_TOKEN"]
+        }
+      end
+    end
+  end
+end

--- a/app/models/api/line_bot/message.rb
+++ b/app/models/api/line_bot/message.rb
@@ -1,0 +1,38 @@
+module Api
+  module LineBot
+    class Message < Api::LineBot::Base
+      def initialize(event)
+        super
+        @event = event
+      end
+
+      class << self
+        def call(event)
+          new(event).call
+        end
+      end
+
+      attr_accessor :event
+
+      def call
+        super
+        return if message_events.length == 0
+        message_events.each do |event|
+          next if event.type != Line::Bot::Event::MessageType::Text
+          message = {
+            type: "text",
+            text: event.message["text"]
+          }
+          client.reply_message(event['replyToken'], message)
+        end
+      end
+
+      private
+
+      def message_events
+        events.select { |event| event.is_a?(Line::Bot::Event::Message) }
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
## チケットへのリンク

* https://example.com

## やったこと

* Line Messaging APIを呼び出すクラスの実装

## やらないこと

* このプルリクでやらないことは何か？（あれば。無いなら「無し」でOK）（やらない場合は、いつやるのかを明記する。）

## できるようになること（ユーザ目線）

* 何ができるようになるのか？（あれば。無いなら「無し」でOK）

## できなくなること（ユーザ目線）

* 何ができなくなるのか？（あれば。無いなら「無し」でOK）

## 動作確認

* ngrokを使って立てたサーバーを経由して以下のようなログが流れること

<img width="998" alt="message_rb_—_qiita-trend-line-bot" src="https://github.com/togo-mentor/qiita-trend-line-bot/assets/64336740/a6eea019-20e3-4e38-92d8-de73c7b2affd">

* LINE画面上で以下のように鸚鵡返しができていること

![IMG_F60BE71AC20B-1](https://github.com/togo-mentor/qiita-trend-line-bot/assets/64336740/aa06c127-0b85-420a-88d4-22ff6b5b571c)


## その他

* レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載）